### PR TITLE
Set light draw distances to meet engine limits

### DIFF
--- a/misc.vpp_pc/lod_properties.xtbl
+++ b/misc.vpp_pc/lod_properties.xtbl
@@ -50,40 +50,40 @@
 		</LOD>
 		<LOD>
 			<Name>light_small</Name>
-			<lod_start_fade_distance>99999</lod_start_fade_distance> <!--From 20-->
-			<lod_fade_duration>21474836</lod_fade_duration> <!--From 1500-->
+			<lod_start_fade_distance>50</lod_start_fade_distance> <!--From 20-->
+			<lod_fade_duration>1500</lod_fade_duration>
 			<_Editor>
 				<Category>Entries:lighting_LOD</Category>
 			</_Editor>
 		</LOD>
 		<LOD>
 			<Name>light_medium</Name>
-			<lod_start_fade_distance>99999</lod_start_fade_distance> <!--From 30-->
-			<lod_fade_duration>21474836</lod_fade_duration> <!--From 1500-->
+			<lod_start_fade_distance>75</lod_start_fade_distance> <!--From 30-->
+			<lod_fade_duration>1500</lod_fade_duration>
 			<_Editor>
 				<Category>Entries:lighting_LOD</Category>
 			</_Editor>
 		</LOD>
 		<LOD>
 			<Name>light_large</Name>
-			<lod_start_fade_distance>99999</lod_start_fade_distance> <!--From 60-->
-			<lod_fade_duration>21474836</lod_fade_duration> <!--From 3000-->
+			<lod_start_fade_distance>150</lod_start_fade_distance> <!--From 60-->
+			<lod_fade_duration>3000</lod_fade_duration>
 			<_Editor>
 				<Category>Entries:lighting_LOD</Category>
 			</_Editor>
 		</LOD>
 		<LOD>
 			<Name>light_extra_large</Name>
-			<lod_start_fade_distance>99999</lod_start_fade_distance> <!--From 75-->
-			<lod_fade_duration>21474836</lod_fade_duration> <!--From 3000-->
+			<lod_start_fade_distance>325</lod_start_fade_distance> <!--From 75-->
+			<lod_fade_duration>3000</lod_fade_duration>
 			<_Editor>
 				<Category>Entries:lighting_LOD</Category>
 			</_Editor>
 		</LOD>
 		<LOD>
 			<Name>light_extra_extra_large</Name>
-			<lod_start_fade_distance>99999</lod_start_fade_distance> <!--From 125-->
-			<lod_fade_duration>21474836</lod_fade_duration> <!--From 4000-->
+			<lod_start_fade_distance>350</lod_start_fade_distance> <!--From 125-->
+			<lod_fade_duration>4000</lod_fade_duration>
 			<_Editor>
 				<Category>Entries:lighting_LOD</Category>
 			</_Editor>


### PR DESCRIPTION

![vlcsnap-2022-09-10-11h39m21s792](https://user-images.githubusercontent.com/89256728/191087417-3dc8c0f9-b3be-4a91-9492-d7933a917f64.jpg)
RFA has a limit of 1024 max lights that can be rendered. Increasing light draw distances to absurd values will cause visual issues in certain levels with lights not working as they should.